### PR TITLE
fix: simplify SKILL.md frontmatter for Claude Code App upload (#3)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,18 +1,6 @@
 ---
 name: humanizer-zh
-description: |
-  去除文本中的 AI 生成痕迹。适用于编辑或审阅文本，使其听起来更自然、更像人类书写。
-  基于维基百科的"AI 写作特征"综合指南。检测并修复以下模式：夸大的象征意义、
-  宣传性语言、以 -ing 结尾的肤浅分析、模糊的归因、破折号过度使用、三段式法则、
-  AI 词汇、否定式排比、过多的连接性短语。
-allowed-tools:
-  - Read
-  - Write
-  - Edit
-  - AskUserQuestion
-metadata:
-  trigger: 编辑或审阅文本，去除 AI 写作痕迹
-  source: 翻译自 blader/humanizer，参考 hardikpandya/stop-slop
+description: Use when editing or reviewing text to remove AI writing patterns and make it sound more natural and human-written.
 ---
 
 # Humanizer-zh: 去除 AI 写作痕迹


### PR DESCRIPTION
## Summary

Fixes #3 — SKILL.md could not be uploaded directly to Claude Code App due to frontmatter format issues.

## Changes

1. **Convert `description` from multiline `|` YAML syntax to single line** — Claude Code App requires a single-line description
2. **Remove `allowed-tools` field** — not supported by Claude Code App
3. **Remove `metadata` field** — not supported by Claude Code App

## Before

\`\`\`yaml
---
name: humanizer-zh
description: |
  去除文本中的 AI 生成痕迹。适用于编辑或审阅文本...
allowed-tools:
  - Read
  - Write
  - Edit
  - AskUserQuestion
metadata:
  trigger: 编辑或审阅文本，去除 AI 写作痕迹
  source: 翻译自 blader/humanizer
---
\`\`\`

## After

\`\`\`yaml
---
name: humanizer-zh
description: Use when editing or reviewing text to remove AI writing patterns and make it sound more natural and human-written.
---
\`\`\`

## Validation

- YAML parses correctly ✓
- Description is single-line ✓
- No `allowed-tools` field ✓
- No `metadata` field ✓
- All other content preserved unchanged
