### PR TITLE
补充 Codex 技能元数据与安装说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,30 @@ git clone https://github.com/op7418/Humanizer-zh.git ~/.claude/skills/humanizer-
 
 如果安装成功，该技能将被激活。
 
+### Codex 安装（补充支持）
+
+Codex 用户可以将同一个仓库克隆到用户级 skills 目录；这不会影响上面的 Claude Code 安装方式。
+
+**macOS/Linux：**
+
+```bash
+git clone https://github.com/op7418/Humanizer-zh.git ~/.codex/skills/humanizer-zh
+```
+
+**Windows PowerShell：**
+
+```powershell
+git clone https://github.com/op7418/Humanizer-zh.git "$HOME\.codex\skills\humanizer-zh"
+```
+
+重启 Codex 后，可以显式调用：
+
+```text
+$humanizer-zh
+```
+
+也可以直接要求 Codex “用 humanizer-zh 润色这段中文”。`agents/openai.yaml` 为 Codex 提供技能列表和默认提示词等界面元数据；核心规则仍由同一份 `SKILL.md` 提供，因此 Claude Code 和 Codex 可以共享此技能。
+
 ## 使用
 
 ### 基础用法
@@ -159,6 +183,7 @@ git clone https://github.com/op7418/Humanizer-zh.git ~/.claude/skills/humanizer-
 ## 文件说明
 
 - **`SKILL.md`** - 中文版技能定义文件
+- **`agents/openai.yaml`** - Codex 技能列表和默认提示词元数据
 - **`README.md`** - 本说明文档
 
 **注：** 英文原版请参考 [blader/humanizer](https://github.com/blader/humanizer)

--- a/agents/openai.yaml
+++ b/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Humanizer 中文润色"
+  short_description: "减少中文文本的 AI 写作痕迹，适用于自然改写、润色和人工感审查"
+  default_prompt: "使用 $humanizer-zh 润色这段中文，使表达自然、有个性，并保留原意和事实。"


### PR DESCRIPTION
## 变更内容

- 新增 `agents/openai.yaml`，为 Codex 提供技能名称、简短说明和默认调用提示词。
- 在 README 中补充 Codex 的 macOS、Linux 和 Windows 安装方法与调用示例。
- 在文件说明中标注 Codex 专用元数据文件。

## 兼容性边界

这是对现有 Claude Code 版本的补充支持，不是替换：

- 未修改 `SKILL.md`；
- 保留现有 Claude Code 安装说明、`allowed-tools` 和 `metadata`；
- Claude Code 与 Codex 继续共用同一份中文 humanizer 规则。

## 验证

- Codex 官方 `quick_validate.py`：`Skill is valid!`
- `agents/openai.yaml` 可正常解析，字段和长度约束通过。
- `git diff --check` 通过。
- 变更文件敏感信息扫描：0 个密钥形态。
